### PR TITLE
Fix: Soften multi-selected cell highlight for readability

### DIFF
--- a/style/variables.css
+++ b/style/variables.css
@@ -264,7 +264,11 @@ all of MD as it is not optimized for dense, information rich UIs.
 
   --jp-notebook-padding: 10px;
   --jp-notebook-select-background: var(--jp-layout-color1);
-  --jp-notebook-multiselected-color: var(--ctp-plt-blue);
+  --jp-notebook-multiselected-color: color-mix(
+    in srgb,
+    var(--ctp-plt-blue),
+    var(--ctp-plt-base) 50%
+  );
 
   /* The scroll padding is calculated to fill enough space at the bottom of the
   notebook to show one single-line cell (with appropriate padding) at the top


### PR DESCRIPTION
This PR slightly adjusts the background colour used for multi-selected notebook cells.

The current highlight is quite strong and can make the underlying code harder to read.
I softened it by blending the accent colour with the base background.

I changed `--jp-notebook-multiselected-color` from:
```css
var(--ctp-plt-blue);
```
to:
```css
color-mix(
  in srgb,
  var(--ctp-plt-blue),
  var(--ctp-plt-base) 50%
);
```

This keeps the selection clearly visible while improving readability.
The colour after the change is also used for table row highlights, so it makes the theme a bit more consistent as well.

Screenshots are attached for comparison.
before (frappe, macchiato)
<img width="1432" height="652" alt="Screenshot From 2026-01-29 12-41-46" src="https://github.com/user-attachments/assets/b32f86c4-27b2-4046-a9c9-a8fa8a8a1ea5" />
<img width="1432" height="652" alt="Screenshot From 2026-01-29 12-41-32" src="https://github.com/user-attachments/assets/e53f2c77-4cf1-4127-8759-a307ff377b78" />

after (frappe, macchiato)
<img width="1432" height="652" alt="Screenshot From 2026-01-29 12-43-03" src="https://github.com/user-attachments/assets/4aaf18e7-c05f-4151-b361-e4cd55fcff27" />
<img width="1432" height="652" alt="Screenshot From 2026-01-29 12-43-10" src="https://github.com/user-attachments/assets/79bd79d2-4312-48aa-801c-f7e336ac3c63" />
