### PR TITLE
chore: migrate to `jupyter-builder`

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,8 +30,8 @@
     "scripts": {
         "build": "jlpm build:lib && jlpm build:labextension:dev",
         "build:prod": "jlpm clean && jlpm build:lib:prod && jlpm build:labextension",
-        "build:labextension": "jupyter labextension build .",
-        "build:labextension:dev": "jupyter labextension build --development True .",
+        "build:labextension": "jupyter-builder build .",
+        "build:labextension:dev": "jupyter-builder build --development True .",
         "build:lib": "tsc --sourceMap",
         "build:lib:prod": "tsc",
         "clean": "jlpm clean:lib",
@@ -51,7 +51,7 @@
         "stylelint:check": "stylelint --cache \"style/**/*.css\"",
         "watch": "run-p watch:src watch:labextension",
         "watch:src": "tsc -w --sourceMap",
-        "watch:labextension": "jupyter labextension watch ."
+        "watch:labextension": "jupyter-builder watch ."
     },
     "dependencies": {
         "@jupyterlab/application": "^3.0.0 || ^4.0.0",
@@ -59,7 +59,7 @@
         "@jupyterlab/settingregistry": "^3.0.0 || ^4.0.0"
     },
     "devDependencies": {
-        "@jupyterlab/builder": "^3.0.0 || ^4.0.0",
+        "@jupyter/builder": "^1.0.0",
         "@types/json-schema": "^7.0.11",
         "@types/react": "^18.0.26",
         "@types/react-addons-linked-state-mixin": "^0.14.22",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling>=1.5.0", "jupyterlab>=3.0.0,<5", "hatch-nodejs-version"]
+requires = ["hatchling>=1.5.0", "hatch-nodejs-version>=0.3.2", "jupyter-builder>=1.0.0"]
 build-backend = "hatchling.build"
 
 [project]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,7 +17,7 @@
     "rootDir": "src",
     "strict": true,
     "strictNullChecks": true,
-    "target": "ES2018"
+    "target": "ES2020"
   },
   "include": ["src/*"]
 }


### PR DESCRIPTION
The current `main` branch doesn't build in *AUR*:

```
INFO:hatch_jupyter_builder.utils:> /tmp/build-env-pv4eevrp/bin/jlpm run build:prod
(Deprecated) 'jupyter labextension build' is deprecated, use 'jupyter-builder build' instead.

@jupyterlab/core-meta was not found in node_modules. This extension declares a devDependency on @jupyterlab/builder@3.0.0 || ^4.0.0, which is a legacy package so core-meta 3.0.0 || ^4.0.0 will be used instead of the latest release.  To avoid this, add @jupyter/builder as a devDependency instead of @jupyterlab/builder.

/tmp/build-env-pv4eevrp/lib/python3.14/site-packages/jupyter_builder/debug_log_file_mixin.py:67: UserWarning: An error occurred.
  warnings.warn("An error occurred.", stacklevel=1)
  /tmp/build-env-pv4eevrp/lib/python3.14/site-packages/jupyter_builder/debug_log_file_mixin.py:68: UserWarning: http.client.InvalidURL: URL can't contain control characters. '/@jupyterlab/core-meta/3.0.0 || ^4.0.0' (found at least ' ')
    warnings.warn(msg[-1].strip(), stacklevel=1)
    /tmp/build-env-pv4eevrp/lib/python3.14/site-packages/jupyter_builder/debug_log_file_mixin.py:69: UserWarning: See the log file for details: /tmp/jupyterlab-debug-3lem9jh6.log
      warnings.warn(f"See the log file for details: {log_path}", stacklevel=1)
```
